### PR TITLE
feature: send email waiting confirmation

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -1,6 +1,8 @@
 class ProviderMailer < ApplicationMailer
+  default from: 'Mercado Fornecedor <mercado.fornecedor@hotmail.com>'
+
   def waiting_administrator_confirmation
     @provider = params[:provider]
-    mail to: @provider.email, subject: "Pending Confirmation - Supplier Market"
+    mail to: @provider.email, subject: "Mercado Fornecedor - Castro Realizado"
   end
 end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -1,0 +1,6 @@
+class ProviderMailer < ApplicationMailer
+  def waiting_administrator_confirmation
+    @provider = params[:provider]
+    mail to: @provider.email, subject: "Pending Confirmation - Supplier Market"
+  end
+end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -3,6 +3,6 @@ class ProviderMailer < ApplicationMailer
 
   def waiting_administrator_confirmation
     @provider = params[:provider]
-    mail to: @provider.email, subject: "Mercado Fornecedor - Castro Realizado"
+    mail to: @provider.email, subject: t('.subject')
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -10,4 +10,14 @@ class Person < ApplicationRecord
   validates :telephone, presence: true
   validates :cnpj,      presence: true
   validates_uniqueness_of :email
+
+  def active_for_authentication?
+    super && active?
+  end
+
+  private
+
+  def active?
+    client || provider || admin
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,3 +1,17 @@
 class Provider < Person
   has_many :products, as: :person, dependent: :destroy
+
+  after_create :send_email_registration_confirmation
+
+  private
+
+  def send_email_registration_confirmation
+    mail = ProviderMailer.with(provider: self).waiting_administrator_confirmation
+
+    begin
+      mail.deliver_now!
+    rescue Exception => e
+      p e.message
+    end
+  end
 end

--- a/app/views/provider_mailer/waiting_administrator_confirmation.html.erb
+++ b/app/views/provider_mailer/waiting_administrator_confirmation.html.erb
@@ -99,10 +99,10 @@ td .es-button-border-2:hover {
                   <td valign="top" align="center" style="padding:0;Margin:0;width:560px"> 
                    <table style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-position:center bottom;background-color:transparent" width="100%" cellspacing="0" cellpadding="0" bgcolor="transparent" role="presentation"> 
                      <tr style="border-collapse:collapse"> 
-                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-bottom:5px;padding-top:10px"><h3 style="Margin:0;line-height:24px;mso-line-height-rule:exactly;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;font-size:20px;font-style:normal;font-weight:bold;color:#2980D9">Cadastro Realizado - Mercado Fornecedor<br><br>Esperando Confirmação do Administrador</h3></td> 
+                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-bottom:5px;padding-top:10px"><h3 style="Margin:0;line-height:24px;mso-line-height-rule:exactly;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;font-size:20px;font-style:normal;font-weight:bold;color:#2980D9"><%= t('.sign_up_successful') %> <br><br> <%= t('.waiting_confirm_admin') %></h3></td> 
                      </tr> 
                      <tr style="border-collapse:collapse"> 
-                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-top:10px"><p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-size:14px;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;line-height:21px;color:#666666">Obrigado <b><%= @provider.name.titleize %></b> por se cadastrar, sua conta está será analisada antes que você possa realizar o login.</p></td> 
+                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-top:10px"><p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-size:14px;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;line-height:21px;color:#666666"><%= t('.thanks_and_waiting_html', { name: @provider.name.titleize }) %>.</p></td> 
                      </tr> 
                    </table></td> 
                  </tr> 

--- a/app/views/provider_mailer/waiting_administrator_confirmation.html.erb
+++ b/app/views/provider_mailer/waiting_administrator_confirmation.html.erb
@@ -99,10 +99,10 @@ td .es-button-border-2:hover {
                   <td valign="top" align="center" style="padding:0;Margin:0;width:560px"> 
                    <table style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-position:center bottom;background-color:transparent" width="100%" cellspacing="0" cellpadding="0" bgcolor="transparent" role="presentation"> 
                      <tr style="border-collapse:collapse"> 
-                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-bottom:5px;padding-top:10px"><h3 style="Margin:0;line-height:24px;mso-line-height-rule:exactly;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;font-size:20px;font-style:normal;font-weight:bold;color:#2980D9">Cadastro Realizado<br><br>Esperando Confirmação do Administrador</h3></td> 
+                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-bottom:5px;padding-top:10px"><h3 style="Margin:0;line-height:24px;mso-line-height-rule:exactly;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;font-size:20px;font-style:normal;font-weight:bold;color:#2980D9">Cadastro Realizado - Mercado Fornecedor<br><br>Esperando Confirmação do Administrador</h3></td> 
                      </tr> 
                      <tr style="border-collapse:collapse"> 
-                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-top:10px"><p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-size:14px;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;line-height:21px;color:#666666">Obrigado <%= @provider.name %> por se cadastrar, sua conta está será analisada antes que você possa realizar o login.</p></td> 
+                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-top:10px"><p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-size:14px;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;line-height:21px;color:#666666">Obrigado <b><%= @provider.name.titleize %></b> por se cadastrar, sua conta está será analisada antes que você possa realizar o login.</p></td> 
                      </tr> 
                    </table></td> 
                  </tr> 

--- a/app/views/provider_mailer/waiting_administrator_confirmation.html.erb
+++ b/app/views/provider_mailer/waiting_administrator_confirmation.html.erb
@@ -1,0 +1,144 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office" style="width:100%;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;padding:0;Margin:0">
+ <head> 
+  <meta charset="UTF-8"> 
+  <meta content="width=device-width, initial-scale=1" name="viewport"> 
+  <meta name="x-apple-disable-message-reformatting"> 
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"> 
+  <meta content="telephone=no" name="format-detection"> 
+  <title>Modelo Email Provedor</title> 
+  <!--[if (mso 16)]>
+    <style type="text/css">
+    a {text-decoration: none;}
+    </style>
+    <![endif]--> 
+  <!--[if gte mso 9]><style>sup { font-size: 100% !important; }</style><![endif]--> 
+  <!--[if gte mso 9]>
+<xml>
+    <o:OfficeDocumentSettings>
+    <o:AllowPNG></o:AllowPNG>
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+</xml>
+<![endif]--> 
+  <!--[if !mso]><!-- --> 
+  <link href="https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i" rel="stylesheet"> 
+  <!--<![endif]--> 
+  <style type="text/css">
+#outlook a {
+	padding:0;
+}
+.ExternalClass {
+	width:100%;
+}
+.ExternalClass,
+.ExternalClass p,
+.ExternalClass span,
+.ExternalClass font,
+.ExternalClass td,
+.ExternalClass div {
+	line-height:100%;
+}
+.es-button {
+	mso-style-priority:100!important;
+	text-decoration:none!important;
+}
+a[x-apple-data-detectors] {
+	color:inherit!important;
+	text-decoration:none!important;
+	font-size:inherit!important;
+	font-family:inherit!important;
+	font-weight:inherit!important;
+	line-height:inherit!important;
+}
+.es-desk-hidden {
+	display:none;
+	float:left;
+	overflow:hidden;
+	width:0;
+	max-height:0;
+	line-height:0;
+	mso-hide:all;
+}
+.es-button-border:hover a.es-button {
+	background:#3498db!important;
+	border-color:#3498db!important;
+}
+.es-button-border:hover {
+	border-color:#1f68b1 #1f68b1 #1f68b1 #1f68b1!important;
+	background:#3498db!important;
+}
+td .es-button-border:hover a.es-button-1 {
+	background:#2980d9!important;
+	border-color:#2980d9!important;
+}
+td .es-button-border-2:hover {
+	background:#2980d9!important;
+}
+@media only screen and (max-width:600px) {p, ul li, ol li, a { font-size:14px!important; line-height:150%!important } h1 { font-size:26px!important; text-align:center; line-height:120%!important } h2 { font-size:24px!important; text-align:center; line-height:120%!important } h3 { font-size:20px!important; text-align:center; line-height:120%!important } h1 a { font-size:26px!important } h2 a { font-size:24px!important } h3 a { font-size:20px!important } .es-menu td a { font-size:13px!important } .es-header-body p, .es-header-body ul li, .es-header-body ol li, .es-header-body a { font-size:13px!important } .es-footer-body p, .es-footer-body ul li, .es-footer-body ol li, .es-footer-body a { font-size:13px!important } .es-infoblock p, .es-infoblock ul li, .es-infoblock ol li, .es-infoblock a { font-size:11px!important } *[class="gmail-fix"] { display:none!important } .es-m-txt-c, .es-m-txt-c h1, .es-m-txt-c h2, .es-m-txt-c h3 { text-align:center!important } .es-m-txt-r, .es-m-txt-r h1, .es-m-txt-r h2, .es-m-txt-r h3 { text-align:right!important } .es-m-txt-l, .es-m-txt-l h1, .es-m-txt-l h2, .es-m-txt-l h3 { text-align:left!important } .es-m-txt-r img, .es-m-txt-c img, .es-m-txt-l img { display:inline!important } .es-button-border { display:block!important } a.es-button { font-size:14px!important; display:block!important; border-left-width:0px!important; border-right-width:0px!important } .es-btn-fw { border-width:10px 0px!important; text-align:center!important } .es-adaptive table, .es-btn-fw, .es-btn-fw-brdr, .es-left, .es-right { width:100%!important } .es-content table, .es-header table, .es-footer table, .es-content, .es-footer, .es-header { width:100%!important; max-width:600px!important } .es-adapt-td { display:block!important; width:100%!important } .adapt-img { width:100%!important; height:auto!important } .es-m-p0 { padding:0px!important } .es-m-p0r { padding-right:0px!important } .es-m-p0l { padding-left:0px!important } .es-m-p0t { padding-top:0px!important } .es-m-p0b { padding-bottom:0!important } .es-m-p20b { padding-bottom:20px!important } .es-mobile-hidden, .es-hidden { display:none!important } tr.es-desk-hidden, td.es-desk-hidden, table.es-desk-hidden { width:auto!important; overflow:visible!important; float:none!important; max-height:inherit!important; line-height:inherit!important } tr.es-desk-hidden { display:table-row!important } table.es-desk-hidden { display:table!important } td.es-desk-menu-hidden { display:table-cell!important } .es-menu td { width:1%!important } table.es-table-not-adapt, .esd-block-html table { width:auto!important } table.es-social { display:inline-block!important } table.es-social td { display:inline-block!important } }
+</style> 
+ </head> 
+ <body style="width:100%;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;padding:0;Margin:0"> 
+  <div class="es-wrapper-color" style="background-color:transparent"> 
+   <!--[if gte mso 9]>
+			<v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
+				<v:fill type="tile" color="transparent"></v:fill>
+			</v:background>
+		<![endif]--> 
+   <table class="es-wrapper" width="100%" cellspacing="0" cellpadding="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;padding:0;Margin:0;width:100%;height:100%;background-repeat:repeat;background-position:center top"> 
+     <tr style="border-collapse:collapse"> 
+      <td valign="top" style="padding:0;Margin:0"> 
+       <table class="es-content" cellspacing="0" cellpadding="0" align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%"> 
+         <tr style="border-collapse:collapse"> 
+          <td align="center" style="padding:0;Margin:0"> 
+           <table class="es-content-body" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:transparent;width:600px" cellspacing="0" cellpadding="0" bgcolor="transparent" align="center"> 
+             <tr style="border-collapse:collapse"> 
+              <td style="padding:0;Margin:0;padding-left:20px;padding-right:20px;background-position:center top;background-color:#FFFFFF" bgcolor="#ffffff" align="left"> 
+               <table width="100%" cellspacing="0" cellpadding="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px"> 
+                 <tr style="border-collapse:collapse"> 
+                  <td valign="top" align="center" style="padding:0;Margin:0;width:560px"> 
+                   <table style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-position:center bottom;background-color:transparent" width="100%" cellspacing="0" cellpadding="0" bgcolor="transparent" role="presentation"> 
+                     <tr style="border-collapse:collapse"> 
+                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-bottom:5px;padding-top:10px"><h3 style="Margin:0;line-height:24px;mso-line-height-rule:exactly;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;font-size:20px;font-style:normal;font-weight:bold;color:#2980D9">Cadastro Realizado<br><br>Esperando Confirmação do Administrador</h3></td> 
+                     </tr> 
+                     <tr style="border-collapse:collapse"> 
+                      <td bgcolor="transparent" align="left" style="padding:0;Margin:0;padding-top:10px"><p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-size:14px;font-family:roboto, 'helvetica neue', helvetica, arial, sans-serif;line-height:21px;color:#666666">Obrigado <%= @provider.name %> por se cadastrar, sua conta está será analisada antes que você possa realizar o login.</p></td> 
+                     </tr> 
+                   </table></td> 
+                 </tr> 
+               </table></td> 
+             </tr> 
+             <tr style="border-collapse:collapse"> 
+              <td style="padding:0;Margin:0;background-position:center bottom" align="left"> 
+               <table width="100%" cellspacing="0" cellpadding="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px"> 
+                 <tr style="border-collapse:collapse"> 
+                  <td valign="top" align="center" style="padding:0;Margin:0;width:600px"> 
+                   <table style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:separate;border-spacing:0px;background-position:center bottom;background-color:#FFFFFF;border-radius:0px 0px 5px 5px" width="100%" cellspacing="0" cellpadding="0" bgcolor="#ffffff" role="presentation"> 
+                     <tr style="border-collapse:collapse"> 
+                      <td height="15" align="center" style="padding:0;Margin:0"></td> 
+                     </tr> 
+                   </table></td> 
+                 </tr> 
+               </table></td> 
+             </tr> 
+             <tr style="border-collapse:collapse"> 
+              <td style="padding:0;Margin:0;padding-left:20px;padding-right:20px;background-position:center bottom" align="left"> 
+               <table width="100%" cellspacing="0" cellpadding="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px"> 
+                 <tr style="border-collapse:collapse"> 
+                  <td valign="top" align="center" style="padding:0;Margin:0;width:560px"> 
+                   <table width="100%" cellspacing="0" cellpadding="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px"> 
+                     <tr style="border-collapse:collapse"> 
+                      <td height="10" align="center" style="padding:0;Margin:0"></td> 
+                     </tr> 
+                   </table></td> 
+                 </tr> 
+               </table></td> 
+             </tr> 
+           </table></td> 
+         </tr> 
+       </table></td> 
+     </tr> 
+   </table> 
+  </div>  
+ </body>
+</html>

--- a/app/views/provider_mailer/waiting_administrator_confirmation.text.erb
+++ b/app/views/provider_mailer/waiting_administrator_confirmation.text.erb
@@ -1,5 +1,5 @@
-Cadastro Realizado
+Cadastro Realizado - Mercado Fornecedor
 Esperando Confirmação do Administrador 
 
                
-Obrigado <%= @provider.name %> por se cadastrar, sua conta está será analisada antes que você possa realizar o login.
+Obrigado <b><%= @provider.name.titleize %></b>e por se cadastrar, sua conta está será analisada antes que você possa realizar o login.

--- a/app/views/provider_mailer/waiting_administrator_confirmation.text.erb
+++ b/app/views/provider_mailer/waiting_administrator_confirmation.text.erb
@@ -1,0 +1,5 @@
+Cadastro Realizado
+Esperando Confirmação do Administrador 
+
+               
+Obrigado <%= @provider.name %> por se cadastrar, sua conta está será analisada antes que você possa realizar o login.

--- a/app/views/provider_mailer/waiting_administrator_confirmation.text.erb
+++ b/app/views/provider_mailer/waiting_administrator_confirmation.text.erb
@@ -1,5 +1,4 @@
-Cadastro Realizado - Mercado Fornecedor
-Esperando Confirmação do Administrador 
+<%= t('.sign_up_successful') %>
+<%= t('.waiting_confirm_admin') %>
 
-               
-Obrigado <b><%= @provider.name.titleize %></b>e por se cadastrar, sua conta está será analisada antes que você possa realizar o login.
+<%= t('.thanks_and_waiting_text', { name: @provider.name.titleize }) %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,12 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+ActionMailer::Base.smtp_settings = {
+  user_name: 'apikey',
+  password: '<apikeySendGrid>',
+  address: 'smtp.sendgrid.net',
+  port: 587,
+  authentication: :plain,
+  enable_starttls_auto: true
+}

--- a/config/locales/email.en.yml
+++ b/config/locales/email.en.yml
@@ -1,0 +1,9 @@
+en:
+  provider_mailer:
+   waiting_administrator_confirmation:
+      subject: "Supplier Market - Registration Successful"
+      sign_up_successful: "Successfully Registered in the Supplier Market"
+      waiting_confirm_admin: "Waiting for Confirmation from the Administrator"
+      thanks_and_waiting_html: "Thank you <b>%{name}</b> for registering, your account will be analyzed and confirmed before you can login"
+      thanks_and_waiting_text: "Thank you %{name} for registering, your account will be analyzed and confirmed before you can login"
+

--- a/config/locales/email.pt.yml
+++ b/config/locales/email.pt.yml
@@ -1,0 +1,11 @@
+# encoding: UTF-8
+
+pt:
+  provider_mailer:
+    waiting_administrator_confirmation:
+      subject: "Mercado Fornecedor - Cadastro Realizado"
+      sign_up_successful: "Cadastro Realizado no Mercado Fornecedor"
+      waiting_confirm_admin: "Esperando Confirmação do Administrador"
+      thanks_and_waiting_html: "Obrigado <b>%{name}</b> por se cadastrar, sua conta está será analisada e confirmada antes que você possa realizar o login"
+      thanks_and_waiting_text: "Obrigado %{name} por se cadastrar, sua conta está será analisada e confirmada antes que você possa realizar o login"
+

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -1,10 +1,16 @@
 FactoryBot.define do
   factory :person do
-    name      { FFaker::Name.name }
+    name      { FFaker::Name.name                }
     telephone { FFaker::PhoneNumber.phone_number }
-    cnpj      { FFaker::IdentificationBR.cnpj }
-    email     { FFaker::Internet.email }
-    password  { FFaker::Internet.password }
+    cnpj      { FFaker::IdentificationBR.cnpj    }
+    email     { FFaker::Internet.email           }
+    password  { FFaker::Internet.password        }
+
+    trait :not_actived do
+      admin    { false }
+      client   { false }
+      provider { false }
+    end
   end
 
   factory :client, class: Client, parent: :person do
@@ -14,5 +20,10 @@ FactoryBot.define do
   factory :provider, class: Provider, parent: :person do
     client   { false }
     provider { true  }
+  end
+
+  factory :adm, class: Adm, parent: :person do
+    client { false }
+    admin  { true  }
   end
 end

--- a/spec/fixtures/provider/waiting_administrator_confirmation
+++ b/spec/fixtures/provider/waiting_administrator_confirmation
@@ -1,0 +1,3 @@
+Provider#waiting_administrator_confirmation
+
+Hi, find me in app/views/provider/waiting_administrator_confirmation

--- a/spec/mailers/previews/provider_preview.rb
+++ b/spec/mailers/previews/provider_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/provider
+class ProviderPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/provider/waiting_administrator_confirmation
+  def waiting_administrator_confirmation
+    ProviderMailer.waiting_administrator_confirmation
+  end
+
+end

--- a/spec/mailers/previews/provider_preview.rb
+++ b/spec/mailers/previews/provider_preview.rb
@@ -1,9 +1,11 @@
-# Preview all emails at http://localhost:3000/rails/mailers/provider
 class ProviderPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/provider/waiting_administrator_confirmation
   def waiting_administrator_confirmation
-    ProviderMailer.waiting_administrator_confirmation
+    provider = Provider.find_by_id(params[:id])
+
+    provider = Provider.new(name: "Example", email: "example@email.com") unless provider
+    ProviderMailer.with(provider: provider).waiting_administrator_confirmation
   end
 
 end

--- a/spec/mailers/previews/provider_preview.rb
+++ b/spec/mailers/previews/provider_preview.rb
@@ -7,5 +7,4 @@ class ProviderPreview < ActionMailer::Preview
     provider = Provider.new(name: "Example", email: "example@email.com") unless provider
     ProviderMailer.with(provider: provider).waiting_administrator_confirmation
   end
-
 end

--- a/spec/mailers/provider_spec.rb
+++ b/spec/mailers/provider_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe ProviderMailer, type: :mailer do
     let!(:mail)     { ProviderMailer.with(provider: provider).waiting_administrator_confirmation }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Mercado Fornecedor - Castro Realizado")
+      expect(mail.subject).to eq("Mercado Fornecedor - Cadastro Realizado")
       expect(mail.to).to eq([provider.email])
       expect(mail.from).to eq(["mercado.fornecedor@hotmail.com"])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Cadastro Realizado - Mercado Fornecedor")
+      expect(mail.body.encoded).to match("Cadastro Realizado no Mercado Fornecedor")
     end
   end
 

--- a/spec/mailers/provider_spec.rb
+++ b/spec/mailers/provider_spec.rb
@@ -2,16 +2,17 @@ require "rails_helper"
 
 RSpec.describe ProviderMailer, type: :mailer do
   describe "waiting_administrator_confirmation" do
-    let(:mail) { ProviderMailer.waiting_administrator_confirmation }
+    let!(:provider) { create(:provider) }
+    let!(:mail)     { ProviderMailer.with(provider: provider).waiting_administrator_confirmation }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Waiting administrator confirmation")
-      expect(mail.to).to eq(["to@example.org"])
-      expect(mail.from).to eq(["from@example.com"])
+      expect(mail.subject).to eq("Mercado Fornecedor - Castro Realizado")
+      expect(mail.to).to eq([provider.email])
+      expect(mail.from).to eq(["mercado.fornecedor@hotmail.com"])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Hi")
+      expect(mail.body.encoded).to match("Cadastro Realizado - Mercado Fornecedor")
     end
   end
 

--- a/spec/mailers/provider_spec.rb
+++ b/spec/mailers/provider_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe ProviderMailer, type: :mailer do
+  describe "waiting_administrator_confirmation" do
+    let(:mail) { ProviderMailer.waiting_administrator_confirmation }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Waiting administrator confirmation")
+      expect(mail.to).to eq(["to@example.org"])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to match("Hi")
+    end
+  end
+
+end

--- a/spec/mailers/provider_spec.rb
+++ b/spec/mailers/provider_spec.rb
@@ -1,19 +1,21 @@
 require "rails_helper"
 
 RSpec.describe ProviderMailer, type: :mailer do
-  describe "waiting_administrator_confirmation" do
+  describe "#waiting_administrator_confirmation" do
     let!(:provider) { create(:provider) }
-    let!(:mail)     { ProviderMailer.with(provider: provider).waiting_administrator_confirmation }
 
+    before(:each) do
+      @mail = ProviderMailer.with(provider: provider).waiting_administrator_confirmation
+    end
+  
     it "renders the headers" do
-      expect(mail.subject).to eq("Mercado Fornecedor - Cadastro Realizado")
-      expect(mail.to).to eq([provider.email])
-      expect(mail.from).to eq(["mercado.fornecedor@hotmail.com"])
+      expect(@mail.subject).to eq("Mercado Fornecedor - Cadastro Realizado")
+      expect(@mail.to).to eq([provider.email])
+      expect(@mail.from).to eq(["mercado.fornecedor@hotmail.com"])
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to match("Cadastro Realizado no Mercado Fornecedor")
+      expect(@mail.body.encoded).to match("Cadastro Realizado no Mercado Fornecedor")
     end
   end
-
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -19,30 +19,30 @@ RSpec.describe Person, type: :model do
     let(:provider_not_actived) { create(:provider, :not_actived) }
     let(:adm_not_actived)      { create(:adm, :not_actived)      }
 
-    context "return must be true" do
-      it "client" do
+    context "when the person is activated, the return must be true" do
+      it "activated client" do
         expect(client.active_for_authentication?).to be_truthy
       end
 
-      it "provider" do
+      it "activated provider" do
         expect(provider.active_for_authentication?).to be_truthy
       end
 
-      it "admin" do
+      it "activated admin" do
         expect(adm.active_for_authentication?).to be_truthy
       end
     end
 
-    context "return must be false" do
-      it "client" do
+    context "same for the others, the return must be false" do
+      it "disabled client" do
         expect(client_not_actived.active_for_authentication?).to be_falsey
       end
 
-      it "provider" do
+      it "disabled provider" do
         expect(provider_not_actived.active_for_authentication?).to be_falsey
       end
 
-      it "admin" do
+      it "disabled admin" do
         expect(adm_not_actived.active_for_authentication?).to be_falsey
       end
     end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Person, type: :model do
       end
     end
 
-    context "same for the others, the return must be false" do
+    context "when the person is disabled, the return must be false" do
       it "disabled client" do
         expect(client_not_actived.active_for_authentication?).to be_falsey
       end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -2,10 +2,49 @@ require 'rails_helper'
 
 RSpec.describe Person, type: :model do
   describe "validations" do
-    it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:name)      }
+    it { is_expected.to validate_presence_of(:email)     }
     it { is_expected.to validate_presence_of(:telephone) }
-    it { is_expected.to validate_presence_of(:cnpj) }
+    it { is_expected.to validate_presence_of(:cnpj)      }
+
     it { is_expected.to validate_uniqueness_of(:email).ignoring_case_sensitivity }
+  end
+
+  describe "#active_for_authentication?" do
+    let(:client)   { create(:client)   }
+    let(:provider) { create(:provider) }
+    let(:adm)      { create(:adm)      }
+
+    let(:client_not_actived)   { create(:client, :not_actived)   }
+    let(:provider_not_actived) { create(:provider, :not_actived) }
+    let(:adm_not_actived)      { create(:adm, :not_actived)      }
+
+    context "return must be true" do
+      it "client" do
+        expect(client.active_for_authentication?).to be_truthy
+      end
+
+      it "provider" do
+        expect(provider.active_for_authentication?).to be_truthy
+      end
+
+      it "admin" do
+        expect(adm.active_for_authentication?).to be_truthy
+      end
+    end
+
+    context "return must be false" do
+      it "client" do
+        expect(client_not_actived.active_for_authentication?).to be_falsey
+      end
+
+      it "provider" do
+        expect(provider_not_actived.active_for_authentication?).to be_falsey
+      end
+
+      it "admin" do
+        expect(adm_not_actived.active_for_authentication?).to be_falsey
+      end
+    end
   end
 end


### PR DESCRIPTION
Now, when a provider registers they will not make an automatic login and the following message will appear:

<kbd>![Mensagem Após Realizar Cadastro](https://user-images.githubusercontent.com/26389226/95603093-30e3b400-0a2c-11eb-828e-7547d787fa3d.jpeg)</kbd>

When trying to login if the provider has not yet been accepted or declined the following message will appear:
<kbd>![Mensagem ao Tentar Logar](https://user-images.githubusercontent.com/26389226/95603238-5c669e80-0a2c-11eb-96b8-929137cf67c2.jpeg)</kbd>

After the registration, an email will be sent confirming and informing that the registration will be analyzed, the email will be in the following style:

<kbd>![Email Recebido](https://user-images.githubusercontent.com/26389226/95603553-d3039c00-0a2c-11eb-9efd-f52d23586956.png)</kbd>

**PS: The settings for sending email is via SMTP using [SendGrid](https://app.sendgrid.com/), an account is required to generate an API key that must be placed in the environment.rb file.**

**PS2: Do not edit the "use_name" field, this is "apikey", what needs to be changed is the <apikeySendGrid>.**

```ruby
ActionMailer::Base.smtp_settings = {
  user_name: 'apikey',
  password: '<apikeySendGrid>',
  address: 'smtp.sendgrid.net',
  port: 587,
  authentication: :plain,
  enable_starttls_auto: true
}
```

![](https://github.trello.services/images/mini-trello-icon.png) [Envio de Email para o Provedor e Mensagem quando se Cadastrar](https://trello.com/c/jQaHJft6/44-envio-de-email-para-o-provedor-e-mensagem-quando-se-cadastrar)
